### PR TITLE
tensorflow docker image moved

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/tensorflow/tensorflow
+FROM tensorflow/tensorflow
 RUN apt-get update && apt-get install -y git-core
 RUN pip install tqdm
 RUN git clone https://github.com/Steven-Hewitt/Entailment-with-Tensorflow.git /notebooks/Entailment


### PR DESCRIPTION
Because the tensorflow doker image has moved, the repository for it needs to be changed in dockerfile. As per: https://stackoverflow.com/questions/51832339/need-help-installing-tensorflow-docker-image